### PR TITLE
Implement close for DatabaseManager

### DIFF
--- a/ai_research_agent.py
+++ b/ai_research_agent.py
@@ -97,6 +97,20 @@ class DatabaseManager:
         self.conn = sqlite3.connect(db_path)
         self._create_tables()
 
+    def __enter__(self) -> "DatabaseManager":
+        """Enter context management."""
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        """Ensure connection is closed on exit."""
+        self.close()
+
+    def close(self) -> None:
+        """Close the underlying SQLite connection."""
+        if self.conn:
+            self.conn.close()
+            self.conn = None
+
     def _create_tables(self) -> None:
         cur = self.conn.cursor()
         cur.execute(
@@ -144,6 +158,7 @@ class ResearchAgent:
             page.text = self.ocr.extract_text(page)
             self.db.save_page(page)
         print(f"Saved {len(pages)} pages to database.")
+        self.db.close()
 
 
 if __name__ == "__main__":  # pragma: no cover - manual execution


### PR DESCRIPTION
## Summary
- add context management methods to `DatabaseManager`
- automatically close the database after running the agent

## Testing
- `python -m py_compile ai_research_agent.py`
- `python ai_research_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_6841f8c81a48832b9399948a500cce53